### PR TITLE
Fix Typo in Comments: "working" Instead of "workinig"

### DIFF
--- a/docs/okhsl.js.html
+++ b/docs/okhsl.js.html
@@ -458,7 +458,7 @@ export const OKLabToOKHSV = (lab, gamut = sRGBGamut, out = vec3()) => {
     s = ((s0 + tMax) * cv) / (tMax * s0 + tMax * k * cv);
   }
 
-  // unlike colorjs.io, we are not worknig with none-types
+  // unlike colorjs.io, we are not working with none-types
   // if (Math.abs(s) &lt; ε || v === 0.0) {
   //   h = null;
   // }

--- a/src/okhsl.js
+++ b/src/okhsl.js
@@ -371,7 +371,7 @@ export const OKLabToOKHSV = (lab, gamut = sRGBGamut, out = vec3()) => {
     s = ((s0 + tMax) * cv) / (tMax * s0 + tMax * k * cv);
   }
 
-  // unlike colorjs.io, we are not worknig with none-types
+  // unlike colorjs.io, we are not working with none-types
   // if (Math.abs(s) < ε || v === 0.0) {
   //   h = null;
   // }


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the comments within both docs/okhsl.js.html and src/okhsl.js. The word "workinig" has been replaced with the correct spelling "working" in the phrase:  
// unlike colorjs.io, we are not working with none-types

No functional code changes were made; this is a documentation/comment fix only.