### PR TITLE
fix: hex alpha, percentage rgb() channels, and rgb() byte clamp

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -172,7 +172,7 @@ const stripAlpha = (coords) => {
 const parseFloatValue = (str) => parseFloat(str) || 0;
 
 const parseColorValue = (str, is255 = false) => {
-  if (is255) return clamp(parseFloatValue(str) / 0xff, 0, 0xff);
+  if (is255) return clamp(parseFloatValue(str) / 0xff, 0, 1);
   else
     return str.includes("%")
       ? parseFloatValue(str) / 100
@@ -202,10 +202,16 @@ export const deserialize = (input) => {
   }
   input = input.trim();
   if (input.charAt(0) === "#") {
-    const rgbIn = input.slice(0, 7);
-    let alphaByte = input.length > 7 ? parseInt(input.slice(7, 9), 16) : 255;
-    let alpha = isNaN(alphaByte) ? 1 : alphaByte / 255;
-    const coords = hexToRGB(rgbIn);
+    const hex = input.slice(1);
+    // alpha is the 4th nibble (#rgba) or last byte (#rrggbbaa) when present
+    let alpha = 1;
+    if (hex.length === 4 || hex.length === 8) {
+      const alphaHex =
+        hex.length === 4 ? hex.charAt(3).repeat(2) : hex.slice(6, 8);
+      const alphaByte = parseInt(alphaHex, 16);
+      if (!isNaN(alphaByte)) alpha = alphaByte / 255;
+    }
+    const coords = hexToRGB(hex);
     if (alpha !== 1) coords.push(alpha);
     return {
       id: "srgb",

--- a/src/core.js
+++ b/src/core.js
@@ -172,11 +172,14 @@ const stripAlpha = (coords) => {
 const parseFloatValue = (str) => parseFloat(str) || 0;
 
 const parseColorValue = (str, is255 = false) => {
+  // a percentage always maps to a 0..1 fraction, regardless of context;
+  // clamp in the rgb() byte context to match its 0..1 channel range
+  if (str.includes("%")) {
+    const v = parseFloatValue(str) / 100;
+    return is255 ? clamp(v, 0, 1) : v;
+  }
   if (is255) return clamp(parseFloatValue(str) / 0xff, 0, 1);
-  else
-    return str.includes("%")
-      ? parseFloatValue(str) / 100
-      : parseFloatValue(str);
+  return parseFloatValue(str);
 };
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -57,14 +57,15 @@ export const constrainAngle = (angle) => ((angle % 360) + 360) % 360;
  */
 export const hexToRGB = (str, out = vec3()) => {
   let hex = str.replace(/#/, "");
-  if (hex.length === 3) {
-    // expand shorthand
-    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
-  } else if (hex.length > 6) {
-    // discard alpha
-    hex = hex.slice(0, 6);
+  if (hex.length <= 4) {
+    // expand shorthand (#rgb or #rgba) by doubling each nibble
+    hex = hex
+      .split("")
+      .map((c) => c + c)
+      .join("");
   }
-  const rgb = parseInt(hex, 16);
+  // discard alpha if present (#rrggbbaa), keeping just the RGB triplet
+  const rgb = parseInt(hex.slice(0, 6), 16);
   out[0] = ((rgb >> 16) & 0xff) / 0xff;
   out[1] = ((rgb >> 8) & 0xff) / 0xff;
   out[2] = (rgb & 0xff) / 0xff;

--- a/test/test.js
+++ b/test/test.js
@@ -309,6 +309,19 @@ test("should deserialize color string information", async (t) => {
     coords: [0, 128 / 0xff, 255 / 0xff, 0.5],
     id: "srgb",
   });
+  // percentage rgb() channels map to a 0..1 fraction (not /255)
+  t.deepEqual(deserialize("rgb(50% 0% 100%)"), {
+    coords: [0.5, 0, 1],
+    id: "srgb",
+  });
+  t.deepEqual(deserialize("rgb(50%, 0%, 100%)"), {
+    coords: [0.5, 0, 1],
+    id: "srgb",
+  });
+  t.deepEqual(deserialize("rgba(50% 0% 100% / 50%)"), {
+    coords: [0.5, 0, 1, 0.5],
+    id: "srgb",
+  });
   t.deepEqual(deserialize("rgb(0, 128, 255, 0.5)"), {
     coords: [0, 128 / 0xff, 255 / 0xff, 0.5],
     id: "srgb",

--- a/test/test.js
+++ b/test/test.js
@@ -349,6 +349,26 @@ test("should deserialize color string information", async (t) => {
     id: "srgb",
     coords: [1, 0, 0.8, 0.8],
   });
+  // shorthand #rgb expands by doubling each nibble
+  t.deepEqual(deserialize("#f0c"), {
+    id: "srgb",
+    coords: [1, 0, 0.8],
+  });
+  // shorthand #rgba carries an alpha nibble
+  t.deepEqual(deserialize("#f0cc"), {
+    id: "srgb",
+    coords: [1, 0, 0.8, 0.8],
+  });
+  // opaque shorthand alpha (f -> ff -> 1) collapses back to 3 coords
+  t.deepEqual(deserialize("#f00f"), {
+    id: "srgb",
+    coords: [1, 0, 0],
+  });
+  // rgb() bytes are normalised into 0..1 and clamped
+  t.deepEqual(deserialize("rgb(300, -20, 255)"), {
+    id: "srgb",
+    coords: [1, 0, 1],
+  });
   t.deepEqual(deserialize("COLOR(sRGB-Linear 0 0.5 1)"), {
     id: "srgb-linear",
     coords: [0, 0.5, 1],


### PR DESCRIPTION
## Summary

Three `deserialize` correctness fixes, each with a repro and test.

### 1. 4-digit / 8-digit hex with alpha
`deserialize("#f00f")` previously returned `[0, 0.941, 0.058]` — garbage — because `hexToRGB` only expanded 3-digit shorthand and `deserialize` only read alpha from the 8-digit slice. CSS supports both `#rgba` and `#rrggbbaa`.
- `hexToRGB` now expands `#rgb`/`#rgba` shorthand by doubling each nibble and discards alpha from `#rrggbbaa`.
- `deserialize` extracts the alpha nibble for both shorthand and full forms.

### 2. Percentage `rgb()` channels (serious)
`rgb(50% 0% 100%)` parsed to `[0.196, 0, 0.392]` because the byte (`is255`) path divided the percentage *number* by 255. A `%` now maps to a `0..1` fraction (`/100`) in any context — `-> [0.5, 0, 1]`, matching CSS / colorjs.io. Affected both comma and space syntaxes.

### 3. `rgb()` byte clamp bound
`parseColorValue` clamped byte channels to `[0, 0xff]` *after* dividing by 255, so the clamp never did anything — `rgb(300,0,0)` yielded `1.176`. Now clamped to `[0, 1]`.

## Tests
Added cases for `#f0c`, `#f0cc`, `#f00f`, `rgb(300,-20,255)`, and the percentage forms (`rgb(50% 0% 100%)`, comma variant, `rgba(... / 50%)`). Full suite: **97 passing**, 0 failures.

https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i