### PR TITLE
feat: add byteToFloat util (inverse of floatToByte)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ In addition to the core API, the module exports a number of utilities:
 
 Converts the float in range 0..1 to a byte in range 0..255, rounded and clamped.
 
+#### `f = byteToFloat(b)`
+
+Converts the byte in range 0..255 to a float in range 0..1. This is the inverse of `floatToByte`; the two round-trip exactly for all 256 byte values.
+
 #### `out = XYZ_to_xyY(xyz, out=[0,0,0])`
 
 Converts the XYZ coordinates to xyY form, storing the result in `out` if specified before returning.

--- a/src/util.js
+++ b/src/util.js
@@ -65,9 +65,9 @@ export const hexToRGB = (str, out = vec3()) => {
     hex = hex.slice(0, 6);
   }
   const rgb = parseInt(hex, 16);
-  out[0] = ((rgb >> 16) & 0xff) / 0xff;
-  out[1] = ((rgb >> 8) & 0xff) / 0xff;
-  out[2] = (rgb & 0xff) / 0xff;
+  out[0] = byteToFloat((rgb >> 16) & 0xff);
+  out[1] = byteToFloat((rgb >> 8) & 0xff);
+  out[2] = byteToFloat(rgb & 0xff);
   return out;
 };
 
@@ -178,13 +178,23 @@ export const XYZ_to_xyY = (arg, out = vec3()) => {
 };
 
 /**
- * Converts a float value to a byte value.
+ * Converts a float value in the range 0..1 to a byte value in the range 0..255, rounded and clamped.
  * @method
  * @param {number} n The float value.
  * @returns {number} The byte value.
  * @category utils
  */
 export const floatToByte = (n) => clamp(Math.round(255 * n), 0, 255);
+
+/**
+ * Converts a byte value in the range 0..255 to a float value in the range 0..1.
+ * This is the inverse of {@link floatToByte}; the two round-trip exactly for all 256 byte values.
+ * @method
+ * @param {number} n The byte value.
+ * @returns {number} The float value.
+ * @category utils
+ */
+export const byteToFloat = (n) => n / 0xff;
 
 /**
  * Creates a new vec3 array.

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ import Color from "colorjs.io";
 import arrayAlmostEqual from "./almost-equal.js";
 import {
   floatToByte,
+  byteToFloat,
   hexToRGB,
   isRGBInGamut,
   RGBToHex,
@@ -389,6 +390,16 @@ test("utils", async (t) => {
   const tmp = [0, 0, 0];
   hexToRGB("#0080ff", tmp);
   t.deepEqual(tmp, [0, 0.5019607843137255, 1]);
+
+  // byteToFloat is the inverse of floatToByte and round-trips exactly
+  t.deepEqual(byteToFloat(0), 0);
+  t.deepEqual(byteToFloat(255), 1);
+  t.deepEqual(byteToFloat(128), 0.5019607843137255);
+  let roundTrips = true;
+  for (let b = 0; b <= 255; b++) {
+    if (floatToByte(byteToFloat(b)) !== b) roundTrips = false;
+  }
+  t.equal(roundTrips, true, "floatToByte(byteToFloat(b)) === b for all bytes");
 });
 
 test("should convert D65 based to D50 based color spaces", async (t) => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -420,11 +420,18 @@ declare module "@texel/color" {
      */
     function XYZ_to_xyY(arg: Vector, out?: Vector): Vector;
     /**
-     * Converts a float value to a byte value.
+     * Converts a float value in the range 0..1 to a byte value in the range 0..255, rounded and clamped.
      * @param n - The float value.
      * @returns The byte value.
      */
     function floatToByte(n: number): number;
+    /**
+     * Converts a byte value in the range 0..255 to a float value in the range 0..1.
+     * This is the inverse of {@link floatToByte}; the two round-trip exactly for all 256 byte values.
+     * @param n - The byte value.
+     * @returns The float value.
+     */
+    function byteToFloat(n: number): number;
     /**
      * Creates a new vec3 array.
      * @returns The vec3 array.


### PR DESCRIPTION
## Summary

The library exports `floatToByte` but not its inverse, and the `/ 0xff` decode logic was inlined three times in `hexToRGB`.

- Adds `byteToFloat(n) = n / 0xff`, exported and typed, as the documented inverse of `floatToByte`.
- Refactors `hexToRGB` to use it — single source of truth for 8-bit ↔ float.

The encode/decode pair round-trips exactly for all 256 byte values (`floatToByte(byteToFloat(b)) === b`), which a new test asserts.

## Tests
Added to the `utils` block. Full suite: **94 passing**, 0 failures. Updated `types.d.ts` and README.

> Note: lightly overlaps with #20 (both touch `hexToRGB`); the hunks are adjacent but distinct, so the second to merge may need a trivial rebase.

https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i)_