### PR TITLE
chore: add sideEffects:false and files allowlist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-bower_components
-node_modules
-*.log
-.DS_Store
-.npmignore
-LICENSE.md
-tools/
-test/
-docs/

--- a/package.json
+++ b/package.json
@@ -3,12 +3,18 @@
   "version": "1.1.11",
   "description": "a minimal and modern color library",
   "type": "module",
+  "sideEffects": false,
   "main": "./src/index.js",
   "types": "./types.d.ts",
   "exports": {
     "import": "./src/index.js",
     "types": "./types.d.ts"
   },
+  "files": [
+    "src",
+    "types.d.ts",
+    "DOC.md"
+  ],
   "license": "MIT",
   "author": {
     "name": "Matt DesLauriers",


### PR DESCRIPTION
## Summary

Two low-risk packaging improvements aligned with the library's compact-bundle goal.

- **`"sideEffects": false`** — the whole architecture is built for tree-shaking, but bundlers were never told it's safe to drop unused modules. Every module only exports pure functions/constants (no top-level side effects), so this is safe and is the single highest-leverage change for bundle size.
- **`"files"` allowlist** (`src`, `types.d.ts`, `DOC.md`) replacing the `.npmignore` denylist. Allowlists are safer against accidentally publishing stray files. `README`/`LICENSE`/`package.json` are always included by npm.

## Verification
`npm pack --dry-run` produces the **identical 20-file set** as before — no change to what's published, just a safer mechanism plus the tree-shaking hint.

https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i)_