### PR TITLE
build: publish a CommonJS dist via esbuild for legacy/CJS consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 __pycache__
 test/logo.png
 .claude/
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-bower_components
-node_modules
-*.log
-.DS_Store
-.npmignore
-LICENSE.md
-tools/
-test/
-docs/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Use [npm](https://npmjs.com/) to install and import the module.
 npm install @texel/color --save
 ```
 
+The package is primarily distributed as ESM (which bundlers can tree-shake). A CommonJS build is also published for legacy Node and CJS-only tooling such as browserify:
+
+```js
+const { convert, OKLCH, sRGB } = require("@texel/color");
+```
+
 ## Examples
 
 Converting OKLCH (cylindrical form of OKLab) to sRGB:

--- a/package.json
+++ b/package.json
@@ -3,12 +3,23 @@
   "version": "1.1.11",
   "description": "a minimal and modern color library",
   "type": "module",
-  "main": "./src/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./src/index.js",
   "types": "./types.d.ts",
   "exports": {
-    "import": "./src/index.js",
-    "types": "./types.d.ts"
+    ".": {
+      "types": "./types.d.ts",
+      "import": "./src/index.js",
+      "require": "./dist/index.cjs",
+      "default": "./src/index.js"
+    }
   },
+  "files": [
+    "src",
+    "dist",
+    "types.d.ts",
+    "DOC.md"
+  ],
   "license": "MIT",
   "author": {
     "name": "Matt DesLauriers",
@@ -33,6 +44,8 @@
   },
   "scripts": {
     "visualize": "canvas-sketch-cli test/canvas-graph.js --open",
+    "build": "esbuild src/index.js --bundle --format=cjs --platform=node --target=node12 --outfile=dist/index.cjs",
+    "prepack": "npm run build",
     "docs": "jsdoc src -r -t node_modules/better-docs -c tools/.jsdoc.json -d docs -R DOC.md",
     "types": "jsdoc src -r -t node_modules/tsd-jsdoc/dist -c tools/.jsdoc.types.json -d .",
     "test": "node test/test.js | faucet",


### PR DESCRIPTION
## Summary

The package was ESM-only (`exports.import` only, no `require`/`default`), so `require()`, browserify, and older Node couldn't load it at all. This adds a CommonJS build using **esbuild** (already a devDependency — no new deps).

- **`npm run build`** bundles `src/index.js` → `dist/index.cjs` (`--format=cjs --target=node12`). The node12 target also downlevels `??` and `?.` for older runtimes (verified: 0 occurrences remain in the bundle).
- **`prepack`** hook builds `dist` automatically on `npm pack` / `npm publish`, so the artifact always matches source.
- **`exports`** map gains `require` + `default` conditions; `main` now points at the CJS bundle (what browserify resolves), while `module`/`import` keep the **tree-shakeable ESM source**.
- `dist` is git-ignored (build artifact) and published via a `files` allowlist.

## Verification
- `require("@texel/color")` resolves all exports and runs `convert` / `serialize` / `gamutMapOKLCH` correctly.
- `npm pack` triggers the build and includes `dist/index.cjs` (21 files).
- ESM test suite still green (90 passing).

> **Note:** Overlaps with #24 (both touch the `files` allowlist / `.npmignore`). Each PR is independently correct against `main`; if both land, expect a trivial `package.json`/`.npmignore` conflict — keep the `files` array that includes `dist`. Recommend merging #24 first.

https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqceM8Xx2mpAvtbC3xhs8i)_